### PR TITLE
fix: make context-menu double-click reliable on Linux/macOS (#24, #26, #12)

### DIFF
--- a/src/core/content.ts
+++ b/src/core/content.ts
@@ -34,6 +34,11 @@ const applySettings = () => {
     "Gesture",
     "distanceThreshold",
   ]);
+  mouseController.contextMenuTimeout = configManager.getPath([
+    "Settings",
+    "Gesture",
+    "contextMenuTimeout",
+  ]);
   mouseController.isTimeoutAbort = configManager.getPath([
     "Settings",
     "Gesture",

--- a/src/core/controller/mouse.ts
+++ b/src/core/controller/mouse.ts
@@ -26,6 +26,11 @@ enum State {
 }
 
 const doubleClickThreshold = 300; // ms
+// Distance tolerance (px) between the two right-clicks that open the context
+// menu. Kept separate from (and more forgiving than) the gesture
+// `distanceThreshold` so a stationary double-click is reliably recognized even
+// with minor cursor jitter between the two clicks.
+const contextMenuDistanceTolerance = 24; // px
 
 export class MouseController {
   private static _instance: MouseController;
@@ -45,6 +50,10 @@ export class MouseController {
   public mouseButton: MouseButton = DefaultConfig.Settings.Gesture.mouseButton;
   public distanceThreshold: number =
     DefaultConfig.Settings.Gesture.distanceThreshold; // px
+  // Max time between the two right-clicks that open the context menu on
+  // platforms where `contextmenu` fires on mouse-down (Linux/macOS). See #24.
+  public contextMenuTimeout: number =
+    DefaultConfig.Settings.Gesture.contextMenuTimeout; // ms
   public suppressionKey: SuppressionKey =
     DefaultConfig.Settings.Gesture.suppressionKey;
   public currentOS: string = "";
@@ -90,10 +99,10 @@ export class MouseController {
 
   private _handleContextMenu = (e: MouseEvent) => {
     const now = Date.now();
-    const withinTime = now - this._lastClick.time < doubleClickThreshold;
+    const withinTime = now - this._lastClick.time < this.contextMenuTimeout;
     const withinDist =
       getDistance(this._lastClick.x, this._lastClick.y, e.clientX, e.clientY) <
-      this.distanceThreshold;
+      contextMenuDistanceTolerance;
 
     if (withinTime && withinDist) {
       this._reset();
@@ -194,6 +203,10 @@ export class MouseController {
           this._state = State.ACTIVE;
           this._enablePreventDefault();
           document.documentElement.setPointerCapture(e.pointerId);
+          // A real gesture started: forget any pending "first right-click" so
+          // the gesture's suppressed contextmenu can't be mistaken for the
+          // second click of a context-menu double-click.
+          this._lastClick = { time: 0, x: 0, y: 0 };
         }
         break;
       }

--- a/src/core/model/config.ts
+++ b/src/core/model/config.ts
@@ -37,6 +37,7 @@ export interface GestureSettings {
   mouseButton: MouseButton;
   suppressionKey: SuppressionKey;
   distanceThreshold: number;
+  contextMenuTimeout: number;
   deviationTolerance: number;
   matchingAlgorithm: MatchingAlgorithm;
   Timeout: TimeoutSettings;
@@ -82,6 +83,7 @@ export const DefaultConfig: ConfigSchema = {
       mouseButton: 2,
       suppressionKey: "none",
       distanceThreshold: 10, // px
+      contextMenuTimeout: 400, // ms
       deviationTolerance: 0.15,
       matchingAlgorithm: "Combined",
       Timeout: {

--- a/src/static/_locales/en/messages.json
+++ b/src/static/_locales/en/messages.json
@@ -118,6 +118,10 @@
     "message": "Distance threshold",
     "description": "Distance threshold"
   },
+  "settingLabelContextMenuTimeout": {
+    "message": "Context menu timeout",
+    "description": "Context menu timeout"
+  },
   "settingLabelDeviationTolerance": {
     "message": "Deviation tolerance",
     "description": "Deviation tolerance"
@@ -200,6 +204,10 @@
   "settingDescriptionDistanceThreshold": {
     "message": "The minimum distance the mouse must be moved until the start of a gesture is recognized.",
     "description": "The minimum distance the mouse must be moved until the start of a gesture is recognized."
+  },
+  "settingDescriptionContextMenuTimeout": {
+    "message": "On Linux and macOS the context menu opens with a double right-click (the browser shows it on mouse-down, so the first click is reserved for gestures). This is the maximum time, in milliseconds, allowed between the two clicks. Increase it if the menu is hard to trigger.",
+    "description": "Explains the context menu timeout setting."
   },
   "settingDescriptionDeviationTolerance": {
     "message": "The permissible gesture deviation that should still be recognized as a match.",

--- a/src/static/options/fragments/settings.html
+++ b/src/static/options/fragments/settings.html
@@ -70,6 +70,15 @@
       </div>
       <div class="ol-item">
         <div class="ol-label">
+          <p data-i18n="settingLabelContextMenuTimeout" class="ol-name"></p>
+          <p data-i18n="settingDescriptionContextMenuTimeout" class="ol-description"></p>
+        </div>
+        <div class="ol-input">
+          <input data-config="Settings.Gesture.contextMenuTimeout" class="input-field" type="number" required step="50" max="2000" min="0">
+        </div>
+      </div>
+      <div class="ol-item">
+        <div class="ol-label">
           <p class="ol-name" data-i18n="settingLabelMatchingAlgorithm"></p>
           <p class="ol-description">
             <span data-i18n="settingDescriptionMatchingAlgorithm"></span>


### PR DESCRIPTION
## Problem

When gestures are bound to the right button, opening the context menu on Linux/macOS takes **3–4 right-clicks** instead of the intended double-click (#24, #26, #12).

On these platforms Chromium fires the `contextmenu` event on **mouse-down**, so the first right-click is necessarily reserved for gesture detection and the menu is meant to open on a *second* click. The detection of that second click, however, required it to land within **300 ms AND within the gesture `distanceThreshold` (10 px)** of the first:

```ts
const withinTime = now - this._lastClick.time < doubleClickThreshold; // 300 ms
const withinDist = getDistance(...) < this.distanceThreshold;          // 10 px (gesture threshold)
```

A normal-paced double-click easily exceeds 300 ms, so the second click falls outside the window, gets suppressed *again*, and `_lastClick` resets to "now" — the user has to keep clicking until two happen to land < 300 ms apart. Reusing the tiny gesture threshold for the click-distance check makes it even more fragile.

## Fix

Keep the existing (and, on Chromium, unavoidable) double-click model, but make it reliable:

- **Configurable, more forgiving time window** — replace the hardcoded 300 ms with `Settings.Gesture.contextMenuTimeout` (default **400 ms**), exposed in the advanced gesture settings so users who want a longer window can set one. This directly addresses the maintainer's note in #12/#18 about adding an option to control this behavior.
- **Decouple the double-click distance** from the gesture `distanceThreshold` via a dedicated, more generous constant (24 px), so minor cursor jitter between the two clicks no longer resets the sequence.
- **Clear the pending first-click when a real gesture starts**, so a gesture's suppressed `contextmenu` can't be mistaken for the second click of a context-menu double-click.

No behavioural change on Windows (where `contextmenu` fires on mouse-up and single-click already works) — only the non-Windows double-click path and its new tunable are affected. Defaults are backward-compatible.

## Testing

Built with `npm run dist` and loaded unpacked in **Brave 1.91.171 / Chromium 149** on **KDE Plasma 6.6 Wayland**:

- Normal-paced double right-click now opens the context menu reliably (previously 3–4 tries).
- Right-button gestures (left/right drag) still work, with the trace drawn.
- No stray context menu appears after completing a gesture.
- New "Context menu timeout" setting appears under advanced gesture settings and takes effect live.

## Note

This does not (and cannot) provide single-right-click context menus *with* right-button gestures on Chromium — that requires the menu to fire on mouse-up, which Chromium does not expose to extensions (see [chromium issue 41029299](https://issues.chromium.org/issues/41029299)). This PR only makes the existing double-click compromise dependable.
