### PR TITLE
Add InsertCustomText command

### DIFF
--- a/docs/commands-todo.md
+++ b/docs/commands-todo.md
@@ -84,10 +84,10 @@ This is a TODO list of commands to be implemented
 - [x]  DecreaseURLNumber
 - [x]  IncreaseURLNumber
 - [x]  ExecuteUserScript
+- [x]  InsertCustomText
 
 ## What's not done yet?
 
-- [ ]  InsertCustomText
 - [ ]  OpenImageInNewTab
 - [ ]  SaveImage(WIP)
 - [ ]  ViewImage

--- a/src/core/background.ts
+++ b/src/core/background.ts
@@ -127,6 +127,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 // TODO: limited items size <= 20
 chrome.tabs.onRemoved.addListener(async (_tabId, removeInfo) => {
   if (removeInfo.isWindowClosing) return;
+  if (!chrome.sessions) return;
 
   const sessions = await chrome.sessions.getRecentlyClosed();
   const sessionId = sessions.find((s) => s.tab)?.tab?.sessionId;

--- a/src/core/commands/index.ts
+++ b/src/core/commands/index.ts
@@ -84,6 +84,7 @@ import {
 } from "@commands/crease-url-number";
 import { UnloadTab } from "./unload";
 import { ExecuteUserScript } from "./user-script";
+import { InsertCustomText } from "@commands/insert-text";
 
 export const commands = {
   NewTab,
@@ -167,6 +168,7 @@ export const commands = {
   IncreaseURLNumber,
   DecreaseURLNumber,
   ExecuteUserScript,
+  InsertCustomText,
 } as const;
 
 export type CommandName = keyof typeof commands;

--- a/src/core/commands/insert-text.ts
+++ b/src/core/commands/insert-text.ts
@@ -1,0 +1,23 @@
+import { CommandFn } from "@utils/types";
+import { defineCommand } from "@commands/commands";
+import { sendTabMessage } from "@utils/message";
+
+interface InsertCustomTextSettings {
+  text?: string;
+}
+
+const InsertCustomTextFn: CommandFn<InsertCustomTextSettings> =
+  async function (sender) {
+    if (!sender.tab?.id) return false;
+    const text = this.getSetting("text");
+    if (!text) return false;
+
+    sendTabMessage(sender.tab.id, "insertText", text);
+    return true;
+  };
+
+export const InsertCustomText = defineCommand(
+  InsertCustomTextFn,
+  { text: "" },
+  "input",
+);

--- a/src/core/content.ts
+++ b/src/core/content.ts
@@ -22,6 +22,7 @@ let displayTrace: boolean = DefaultConfig.Settings.Gesture.Trace.display;
 let displayCommand: boolean = DefaultConfig.Settings.Gesture.Command.display;
 
 let contextData: Context;
+let gestureTargetElement: HTMLElement | null = null;
 
 const applySettings = () => {
   mouseController.mouseButton = configManager.getPath([
@@ -104,6 +105,8 @@ async function main() {
 mouseController.addEventListener("register", (_es, e) => {
   // collect contextual data, run as early as possible
   contextData = Context.fromEvent(e);
+  const composedPath = e.composedPath();
+  gestureTargetElement = (composedPath[0] ?? e.target) as HTMLElement;
 });
 
 mouseController.addEventListener("start", (es, e) => {
@@ -230,11 +233,54 @@ const handleClipboardWriteImage: Handler<
   await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
 };
 
+function insertTextAtCaret(text: string, target: HTMLElement | null): boolean {
+  if (
+    (target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement) &&
+    !target.disabled &&
+    !target.readOnly
+  ) {
+    const start = target.selectionStart ?? target.value.length;
+    const end = target.selectionEnd ?? target.value.length;
+    const value = target.value;
+
+    target.value = value.slice(0, start) + text + value.slice(end);
+    target.selectionStart = target.selectionEnd = start + text.length;
+    target.dispatchEvent(new Event("input", { bubbles: true }));
+    return true;
+  }
+
+  if (target?.isContentEditable) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return false;
+
+    const range = selection.getRangeAt(0);
+    range.deleteContents();
+
+    const node = document.createTextNode(text);
+    range.insertNode(node);
+    range.setStartAfter(node);
+    range.setEndAfter(node);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    target.dispatchEvent(new Event("input", { bubbles: true }));
+    return true;
+  }
+
+  return false;
+}
+
+const handleInsertText: Handler<"insertText", ContentMessages> = (m) => {
+  insertTextAtCaret(m.data, gestureTargetElement);
+};
+
 const contentHandlers: HandlerMap<ContentMessages> = {
   matchingGesture: handleMatchingGesture,
   clipboardWriteText: handleClipboardWriteText,
   clipboardReadText: handleClipboardReadText,
   clipboardWriteImage: handleClipboardWriteImage,
+  insertText: handleInsertText,
 };
 
 registerHandlers(contentHandlers);

--- a/src/core/utils/message.ts
+++ b/src/core/utils/message.ts
@@ -73,6 +73,7 @@ export type ContentMessages = {
   clipboardWriteText: string;
   clipboardReadText: Record<string, never>;
   clipboardWriteImage: string; // url to image
+  insertText: string;
 };
 
 export function waitForVoidMessage(subject: string): Promise<any> {


### PR DESCRIPTION
Inserts user-defined text at the caret position of the element the gesture started on (input, textarea, or contenteditable), without relying on the deprecated document.execCommand API.

Also guards the recently-closed-tabs tracker against chrome.sessions being undefined when the optional "sessions" permission hasn't been granted yet, which threw on every tab close.